### PR TITLE
Fix for skins list not resetting after each use

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,11 +8,12 @@ function load() {
 }
 
 // Read and convert skins
-var skins = [];
+var skins;
 function handleImage(e) {
     const files   = e.currentTarget.files;
     var x = 0,  y = 0;
     canvas.height = 64;
+    skins         = [];
     // Loop over all selected files
     Object.keys(files).forEach(i => {
         const file = files[i];


### PR DESCRIPTION
This PR is just a small fix for the list of uploaded skins not clearing itself after each upload. 

Having it not reset each upload is a potentially useful feature that could be revisited later, but in this case the behavior is a bug and should be removed.